### PR TITLE
add CODEOWNERS manually because baton-procore is a special snowflake

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @laurenleach @btipling


### PR DESCRIPTION
Adds a CODEOWNERS file because I can't do this via Pulumi.