### PR TITLE
fix: migrate off deprecated SDK trait options to fix lint

### DIFF
--- a/pkg/connector/companies.go
+++ b/pkg/connector/companies.go
@@ -33,9 +33,8 @@ func companyResource(company client.Company) (*v2.Resource, error) {
 		company.Name,
 		companyResourceType,
 		company.Id,
-		[]resourceSdk.GroupTraitOption{
-			resourceSdk.WithGroupProfile(profile),
-		},
+		nil,
+		resourceSdk.WithResourceProfile(profile),
 		resourceSdk.WithAnnotation(
 			&v2.ChildResourceType{ResourceTypeId: projectResourceType.Id},
 			&v2.ChildResourceType{ResourceTypeId: userResourceType.Id},

--- a/pkg/connector/projects.go
+++ b/pkg/connector/projects.go
@@ -21,11 +21,7 @@ type projectBuilder struct {
 }
 
 func getCompanyId(resource *v2.Resource) (string, error) {
-	groupTrait, err := resourceSdk.GetGroupTrait(resource)
-	if err != nil {
-		return "", fmt.Errorf("failed to extract group traits from project resource: %w", err)
-	}
-	traits := groupTrait.GetProfile().AsMap()
+	traits := resourceSdk.GetProfile(resource).AsMap()
 	companyId, ok := traits["company_id"].(string)
 	if !ok {
 		return "", fmt.Errorf("company_id missing from project resource profile")
@@ -48,9 +44,8 @@ func projectResource(project client.Project) (*v2.Resource, error) {
 		project.Name,
 		projectResourceType,
 		project.Id,
-		[]resourceSdk.GroupTraitOption{
-			resourceSdk.WithGroupProfile(profile),
-		},
+		nil,
+		resourceSdk.WithResourceProfile(profile),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/connector/users.go
+++ b/pkg/connector/users.go
@@ -32,9 +32,9 @@ func userResource(user client.User) (*v2.Resource, error) {
 		"contact": false,
 	}
 
-	status := v2.UserTrait_Status_STATUS_ENABLED
+	status := v2.Status_RESOURCE_STATUS_ENABLED
 	if !user.IsActive {
-		status = v2.UserTrait_Status_STATUS_DISABLED
+		status = v2.Status_RESOURCE_STATUS_DISABLED
 	}
 
 	ret, err := resourceSdk.NewUserResource(
@@ -42,14 +42,14 @@ func userResource(user client.User) (*v2.Resource, error) {
 		userResourceType,
 		user.Id,
 		[]resourceSdk.UserTraitOption{
-			resourceSdk.WithUserProfile(profile),
 			resourceSdk.WithEmail(user.EmailAddress, true),
 			resourceSdk.WithEmployeeID(user.EmployeeId),
-			resourceSdk.WithCreatedAt(user.CreatedAt),
 			resourceSdk.WithLastLogin(user.LastLoginAt),
-			resourceSdk.WithStatus(status),
 			resourceSdk.WithAccountType(v2.UserTrait_ACCOUNT_TYPE_HUMAN),
 		},
+		resourceSdk.WithResourceProfile(profile),
+		resourceSdk.WithResourceCreatedAt(user.CreatedAt),
+		resourceSdk.WithResourceStatus(status, ""),
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Why lint broke on main

`baton-sdk` was bumped **v0.18.4 → v0.19.0** (commit `89aee42`), which added `SA1019` deprecation annotations to several trait-level resource options. PR #42's `verify / lint` had passed because its branch was last linted against v0.18.4, where those functions weren't yet deprecated — GitHub doesn't re-run a PR's checks against latest main at merge time. Once #42 merged, the post-merge push to main linted the SDK bump and the connector code *together* for the first time, and staticcheck fired on all 6 call sites.

## Fix

Migrate off the deprecated trait options to the resource-level equivalents:

| Deprecated | Replacement |
| :--- | :--- |
| `WithGroupProfile` / `WithUserProfile` | `WithResourceProfile` |
| `WithCreatedAt` | `WithResourceCreatedAt` |
| `WithStatus` (`UserTrait_Status_Status`) | `WithResourceStatus` (`Status_ResourceStatus`) |
| `groupTrait.GetProfile()` | `resourceSdk.GetProfile(resource)` |

The profile/created_at/status options move out of the trait-option slice into the variadic `ResourceOption`s of `NewUserResource`/`NewGroupResource`.

## Verification

- `go build ./cmd/baton-procore` ✅
- `golangci-lint run --timeout=6m` → **0 issues** ✅
- `go test -mod=vendor ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)